### PR TITLE
possible typo in scanner.py

### DIFF
--- a/Lib/json/scanner.py
+++ b/Lib/json/scanner.py
@@ -68,6 +68,6 @@ def py_make_scanner(context):
         finally:
             memo.clear()
 
-    return _scan_once
+    return scan_once
 
 make_scanner = c_make_scanner or py_make_scanner


### PR DESCRIPTION
Should "py_make_scanner" return "scan_once" function rather than "_scan_once"?